### PR TITLE
Add etch address

### DIFF
--- a/contracts/interfaces/IEndorser.sol
+++ b/contracts/interfaces/IEndorser.sol
@@ -69,5 +69,5 @@ interface IEndorser {
      * Returns the address this contract should be located at when performing simulations.
      * @return etchAddress The address this contract should be located at when performing simulations.
      */
-    function etchAddress() external view returns (address etchAddress);
+    function etchAddress() external view returns (address payable etchAddress);
 }


### PR DESCRIPTION
I propose adding `function etchAddress() returns (address) external;` to the `IEndorser` spec. 

This will solve an issue where simulations in an Untrusted Context can only be completed from a given address (e.g. ERC-4337). 

Currently simulating 4337 transactions requires either calling the entire operation on chain (defeats the value of 5189) or being unable to call `IAccount.validateUserOp`. 

![image](https://github.com/0xsequence/erc5189-libs/assets/1460552/c05e8f94-5df0-4506-a858-74c9fdb721d7)

The proposal allows an Endorser to specify which address the endorser code should be located at when performing simulations. e.g. A 4337Endorser would be able to specify it's own address as the 4337 EntryPoint address. This will allow it to call `IAccount.validateUserOp`. 

![image](https://github.com/0xsequence/erc5189-libs/assets/1460552/db338542-5d77-4dd0-ab1f-fecec44e69e8)

This is similar to how ERC-4337 performs simulations via https://eips.ethereum.org/EIPS/eip-7562. 

Note the naming is taken from foundry's `etch` command. https://book.getfoundry.sh/cheatcodes/etch